### PR TITLE
Add readme and adjust docker building

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
-# auto-sqlancer
+# Auto-sqlancer
 A suite of automation scripts that streamline the sqlancer testing process.
+
+
+## Minimum Requirements
+- Python 3.7 or above
+- Java 11 or above
+- Docker
+
+## Using Auto-sqlancer
+### 1. Test all DBMSs
+
+```bash
+python3 start.py test --dbms all [--cache]
+```
+
+- --dbms all: test all the databases
+
+- --cache(optional): skip pulling/building Docker image
+
+### 2. Test a single DBMS
+
+```bash
+python3 start.py test --dbms <dbms_name> --config <path/to/config.json> [--cache]
+
+```
+
+- <dbms_name>: e.g., mysql, postgres, sqlite, etc.
+
+- --config: Path to the config file for the selected DBMS.
+
+- Example: 
+```
+python3 start.py test --dbms mysql --config mysql/config.json
+```
+
+### 3. Test a Custom Dockerfile-Based DBMS Container
+```bash
+python3 start.py test --dockerfile <path/to/Dockerfile> --config <path/to/config.json> [--cache]
+```
+
+- --dockerfile: Path to the custom Dockerfile to build the DBMS image.
+
+- --config: Path to the DBMS config file.
+
+- Example: 
+```
+python3 start.py test --dockerfile ./Dockerfile --config mysql/config.json
+```

--- a/mysql/config.json
+++ b/mysql/config.json
@@ -1,6 +1,6 @@
 {
   "image": "mysql:8.0",
-  "container_name": "mysql",
+  "container_name": "mysql-sqlancer",
   "port": 3306,
   "env": {
     "MYSQL_ROOT_PASSWORD": "12345678"

--- a/mysql/config.json
+++ b/mysql/config.json
@@ -1,6 +1,6 @@
 {
   "image": "mysql:8.0",
-  "container_name": "mysql-test",
+  "container_name": "mysql",
   "port": 3306,
   "env": {
     "MYSQL_ROOT_PASSWORD": "12345678"

--- a/postgres/config.json
+++ b/postgres/config.json
@@ -1,6 +1,6 @@
 {
     "image": "postgres:13",
-    "container_name": "postgres",
+    "container_name": "postgres-sqlancer",
     "port": 5432,
     "env": {
       "POSTGRES_USER": "postgres",

--- a/postgres/config.json
+++ b/postgres/config.json
@@ -1,6 +1,6 @@
 {
     "image": "postgres:13",
-    "container_name": "postgres-test",
+    "container_name": "postgres",
     "port": 5432,
     "env": {
       "POSTGRES_USER": "postgres",

--- a/run_test.py
+++ b/run_test.py
@@ -45,7 +45,7 @@ def start_db_container(dbms, config_path):
 
     cfg = load_json(config_path)
     image = cfg.get("image")
-    container_name = cfg.get("container_name", f"{dbms}-test")
+    container_name = cfg.get("container_name", f"{dbms}-sqlancer")
     port = str(cfg.get("port", "3306"))
     env_dict = cfg.get("env", {})
 
@@ -94,7 +94,7 @@ def start_db_container(dbms, config_path):
 def start_sqlancer_container(dbms, host_container_name, username, password, oracle, threads, timeout):
     run_command([
         "docker", "run", "--rm",
-        "--name", "sqlancer-runner",
+        "--name", "auto-sqlancer",
         "--network", "sqlancer-net",
         "-e", f"SQLANCER_DBMS={dbms}",
         "-e", f"SQLANCER_HOST={host_container_name}",

--- a/run_test.py
+++ b/run_test.py
@@ -13,7 +13,12 @@ def run_command(cmd, **kwargs):
     print("[CMD]", " ".join(cmd))
     subprocess.run(cmd, check=True, **kwargs)
 
-def ensure_sqlancer_image():
+def ensure_sqlancer_image(force_rebuild=False):
+    if force_rebuild:
+        print("[INFO] Rebuilding SQLancer image due to --cache not specified...")
+        run_command(["docker", "build", "--no-cache", "-t", "sqlancer:latest", "./sqlancer"])
+        return
+
     result = subprocess.run(
         ["docker", "images", "--format", "{{.Repository}}:{{.Tag}}"],
         capture_output=True, text=True
@@ -24,6 +29,7 @@ def ensure_sqlancer_image():
     else:
         print("[INFO] SQLancer image not found. Building from ./sqlancer...")
         run_command(["docker", "build", "-t", "sqlancer:latest", "./sqlancer"])
+
 
 def container_exists(name):
     result = subprocess.run(
@@ -86,7 +92,6 @@ def start_db_container(dbms, config_path):
             print(f"[WARNING] Failed to run init SQL: {e}")
 
 def start_sqlancer_container(dbms, host_container_name, username, password, oracle, threads, timeout):
-    ensure_sqlancer_image()
     run_command([
         "docker", "run", "--rm",
         "--name", "sqlancer-runner",
@@ -103,7 +108,7 @@ def start_sqlancer_container(dbms, host_container_name, username, password, orac
 
 def test_single(dbms, config_path, use_cache=False):
     ensure_network_exists()
-    ensure_sqlancer_image()
+    ensure_sqlancer_image(force_rebuild=not use_cache)
     cfg = load_json(config_path)
 
     image = cfg["image"]
@@ -141,7 +146,7 @@ def test_all(use_cache=False):
         test_single(dbms, config_path, use_cache)
 
 def test_custom_dockerfile(dockerfile_path, config_path, use_cache=False):
-    ensure_sqlancer_image()
+    ensure_sqlancer_image(force_rebuild=not use_cache)
     cfg = load_json(config_path)
     dbms = cfg["dbms"]
     tag = f"{dbms}-custom"


### PR DESCRIPTION
1. Edit readme to include dependencies and usage.
2. Force sqlancer to rebuild when --cache is not set.