### PR TITLE
persist logs to auto-sqlancer/logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 logs/
+sqlancer-logs/
 
 __pycache__/
 **/__pycache__/

--- a/run_test.py
+++ b/run_test.py
@@ -93,9 +93,8 @@ def start_db_container(dbms, config_path):
             print(f"[WARNING] Failed to run init SQL: {e}")
 
 def start_sqlancer_container(dbms, host_container_name, username, password, oracle, threads, timeout):
-    date = datetime.today().strftime("%Y-%m-%d")  
-    time = datetime.today().strftime("%H-%M-%S")  
-    log_dir_host = os.path.abspath(os.path.join("logs", date, time))
+    date = datetime.today().strftime("%Y-%m-%d-%H-%M-%S")  
+    log_dir_host = os.path.abspath(os.path.join("logs", date))
     os.makedirs(log_dir_host, exist_ok=True)
 
     run_log_container_dir = "/logs"
@@ -124,7 +123,7 @@ def test_single(dbms, config_path, use_cache=False):
     cfg = load_json(config_path)
 
     image = cfg["image"]
-    container_name = cfg.get("container_name", f"{dbms}-test")
+    container_name = cfg.get("container_name", f"{dbms}-sqlancer")
     username = cfg["username"]
     password = cfg["password"]
     oracle = cfg["oracle"]

--- a/run_test.py
+++ b/run_test.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 import time
 import shlex
+from datetime import datetime
 
 def load_json(path):
     with open(path) as f:
@@ -92,6 +93,14 @@ def start_db_container(dbms, config_path):
             print(f"[WARNING] Failed to run init SQL: {e}")
 
 def start_sqlancer_container(dbms, host_container_name, username, password, oracle, threads, timeout):
+    date = datetime.today().strftime("%Y-%m-%d")  
+    time = datetime.today().strftime("%H-%M-%S")  
+    log_dir_host = os.path.abspath(os.path.join("logs", date, time))
+    os.makedirs(log_dir_host, exist_ok=True)
+
+    run_log_container_dir = "/logs"
+    sqlancer_logs_container_dir = "/root/sqlancer/target/logs"
+
     run_command([
         "docker", "run", "--rm",
         "--name", "auto-sqlancer",
@@ -103,8 +112,11 @@ def start_sqlancer_container(dbms, host_container_name, username, password, orac
         "-e", f"SQLANCER_ORACLE={oracle}",
         "-e", f"SQLANCER_THREADS={threads}",
         "-e", f"SQLANCER_TIMEOUT={timeout}",
+        "-v", f"{log_dir_host}:{run_log_container_dir}",
+        "-v", f"{log_dir_host}:{sqlancer_logs_container_dir}",
         "sqlancer:latest"
     ])
+
 
 def test_single(dbms, config_path, use_cache=False):
     ensure_network_exists()

--- a/run_test.py
+++ b/run_test.py
@@ -93,7 +93,7 @@ def start_db_container(dbms, config_path):
             print(f"[WARNING] Failed to run init SQL: {e}")
 
 def start_sqlancer_container(dbms, host_container_name, username, password, oracle, threads, timeout):
-    date = datetime.today().strftime("%Y-%m-%d-%H-%M-%S")  
+    date = datetime.today().strftime("%y-%m-%d-%H-%M-%S")  
     log_dir_host = os.path.abspath(os.path.join("logs", date))
     os.makedirs(log_dir_host, exist_ok=True)
 

--- a/sqlancer/entrypoint.sh
+++ b/sqlancer/entrypoint.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+LOG_DIR="/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="${LOG_DIR}/sqlancer.log"
+
 echo "=== SQLancer container start ==="
 echo "Waiting for DB to become healthy..."
 
@@ -13,14 +18,13 @@ for i in {1..60}; do
   sleep 1
 done
 
-echo "[INFO] DB host will be: $SQLANCER_HOST"
-echo "Running: java -jar sqlancer-*.jar --num-threads $SQLANCER_THREADS --timeout-seconds $SQLANCER_TIMEOUT --username $SQLANCER_USERNAME --password $SQLANCER_PASSWORD --host $SQLANCER_HOST $SQLANCER_DBMS --oracle $SQLANCER_ORACLE"
+# Prepare the command string
+CMD="java -jar sqlancer-*.jar --num-threads \"$SQLANCER_THREADS\" --timeout-seconds \"$SQLANCER_TIMEOUT\" --username \"$SQLANCER_USERNAME\" --password \"$SQLANCER_PASSWORD\" --host \"$SQLANCER_HOST\" \"$SQLANCER_DBMS\" --oracle \"$SQLANCER_ORACLE\""
 
-exec java -jar sqlancer-*.jar \
-  --num-threads "$SQLANCER_THREADS" \
-  --timeout-seconds "$SQLANCER_TIMEOUT" \
-  --username "$SQLANCER_USERNAME" \
-  --password "$SQLANCER_PASSWORD" \
-  --host "$SQLANCER_HOST" \
-  "$SQLANCER_DBMS" \
-  --oracle "$SQLANCER_ORACLE"
+# Print command to console and log file
+echo "Running: $CMD" | tee -a "$LOG_FILE"
+
+# Run the command and tee output to both console and log file
+eval "$CMD" 2>&1 | tee -a "$LOG_FILE"
+
+echo "[INFO] SQLancer finished. Logs saved to $LOG_FILE"


### PR DESCRIPTION
Persist SQLancer logs in logs/YY-MM-DD/HH-MM-SS directories.
E.g.
logs/
&nbsp;&nbsp;-25-07-16-18-47-53/
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-mysql/
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-database0-cur.log
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-database1-cur.log
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-database2-cur.log
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-database3-cur.log
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-sqlancer.log