### PR TITLE
Support cockroachdb

### DIFF
--- a/cockroachdb/config.json
+++ b/cockroachdb/config.json
@@ -1,7 +1,7 @@
 {
     "embedded": "no",
     "dbms": "cockroachdb",
-    "image": "cockroachdb/cockroach:latest",
+    "image": "cockroachdb/cockroach:v24.1.0",
     "container_name": "cockroachdb-sqlancer",
     "port": 26257,
     "startup_cmd": [

--- a/cockroachdb/config.json
+++ b/cockroachdb/config.json
@@ -10,7 +10,7 @@
     ],
     "username": "root",
     "password": "",
-    "oracle": "CERT",
+    "oracle": "NOREC",
     "num_threads": 4,
     "timeout_seconds": 60
   }

--- a/cockroachdb/config.json
+++ b/cockroachdb/config.json
@@ -1,7 +1,7 @@
 {
     "embedded": "no",
     "dbms": "cockroachdb",
-    "image": "cockroachdb/cockroach:v24.1.0",
+    "image": "cockroachdb/cockroach:latest",
     "container_name": "cockroachdb-sqlancer",
     "port": 26257,
     "startup_cmd": [

--- a/cockroachdb/config.json
+++ b/cockroachdb/config.json
@@ -1,0 +1,17 @@
+{
+    "embedded": "no",
+    "dbms": "cockroachdb",
+    "image": "cockroachdb/cockroach:v24.1.0",
+    "container_name": "cockroachdb-sqlancer",
+    "port": 26257,
+    "startup_cmd": [
+        "start-single-node",
+        "--insecure"
+    ],
+    "username": "root",
+    "password": "",
+    "oracle": "CERT",
+    "num_threads": 4,
+    "timeout_seconds": 60
+  }
+  

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "dbms_list": ["mysql", "postgres", "sqlite", "tidb"],
+  "dbms_list": ["mysql", "postgres", "sqlite", "tidb", "cockroachdb"],
   "dbms": "mysql",
   "container_name": "mysql-custom",
   "image": "mysql-custom",

--- a/sqlancer/Dockerfile
+++ b/sqlancer/Dockerfile
@@ -1,15 +1,47 @@
+# FROM ubuntu:20.04
+
+# ENV DEBIAN_FRONTEND=noninteractive
+
+# RUN apt-get update && \
+#     apt-get install -y openjdk-17-jdk maven git jq netcat mysql-client && \
+#     rm -rf /var/lib/apt/lists/*
+
+# WORKDIR /root/sqlancer
+
+# RUN git clone https://github.com/sqlancer/sqlancer.git . && \
+#     mvn clean package -DskipTests
+
+# COPY entrypoint.sh /root/entrypoint.sh
+# RUN chmod +x /root/entrypoint.sh
+
+# CMD ["/root/entrypoint.sh"]
+
 FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y openjdk-17-jdk maven git jq netcat mysql-client && \
+    apt-get install -y --no-install-recommends \
+      openjdk-17-jdk maven git jq netcat mysql-client \
+      curl ca-certificates bash grep sed && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root/sqlancer
 
+ARG SQLANCER_REF=main
+
 RUN git clone https://github.com/sqlancer/sqlancer.git . && \
-    mvn clean package -DskipTests
+    git checkout "${SQLANCER_REF}" && \
+    echo ">>> scanning for deprecated CockroachDB settings..." && \
+    PC_ENABLED_FILES="$(grep -RIl 'sql.metrics.statement_details.plan_collection.enabled' || true)" && \
+    if [ -n "$PC_ENABLED_FILES" ]; then \
+      echo "$PC_ENABLED_FILES" | xargs -r sed -i "/sql.metrics.statement_details.plan_collection.enabled/d"; \
+    fi && \
+    PC_PERIOD_FILES="$(grep -RIl 'sql.metrics.statement_details.plan_collection.period' || true)" && \
+    if [ -n "$PC_PERIOD_FILES" ]; then \
+      echo "$PC_PERIOD_FILES" | xargs -r sed -i "/sql.metrics.statement_details.plan_collection.period/d"; \
+    fi && \
+    mvn -q -DskipTests clean package
 
 COPY entrypoint.sh /root/entrypoint.sh
 RUN chmod +x /root/entrypoint.sh

--- a/sqlancer/Dockerfile
+++ b/sqlancer/Dockerfile
@@ -1,47 +1,15 @@
-# FROM ubuntu:20.04
-
-# ENV DEBIAN_FRONTEND=noninteractive
-
-# RUN apt-get update && \
-#     apt-get install -y openjdk-17-jdk maven git jq netcat mysql-client && \
-#     rm -rf /var/lib/apt/lists/*
-
-# WORKDIR /root/sqlancer
-
-# RUN git clone https://github.com/sqlancer/sqlancer.git . && \
-#     mvn clean package -DskipTests
-
-# COPY entrypoint.sh /root/entrypoint.sh
-# RUN chmod +x /root/entrypoint.sh
-
-# CMD ["/root/entrypoint.sh"]
-
 FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      openjdk-17-jdk maven git jq netcat mysql-client \
-      curl ca-certificates bash grep sed && \
+    apt-get install -y openjdk-17-jdk maven git jq netcat mysql-client && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root/sqlancer
 
-ARG SQLANCER_REF=main
-
 RUN git clone https://github.com/sqlancer/sqlancer.git . && \
-    git checkout "${SQLANCER_REF}" && \
-    echo ">>> scanning for deprecated CockroachDB settings..." && \
-    PC_ENABLED_FILES="$(grep -RIl 'sql.metrics.statement_details.plan_collection.enabled' || true)" && \
-    if [ -n "$PC_ENABLED_FILES" ]; then \
-      echo "$PC_ENABLED_FILES" | xargs -r sed -i "/sql.metrics.statement_details.plan_collection.enabled/d"; \
-    fi && \
-    PC_PERIOD_FILES="$(grep -RIl 'sql.metrics.statement_details.plan_collection.period' || true)" && \
-    if [ -n "$PC_PERIOD_FILES" ]; then \
-      echo "$PC_PERIOD_FILES" | xargs -r sed -i "/sql.metrics.statement_details.plan_collection.period/d"; \
-    fi && \
-    mvn -q -DskipTests clean package
+    mvn clean package -DskipTests
 
 COPY entrypoint.sh /root/entrypoint.sh
 RUN chmod +x /root/entrypoint.sh

--- a/test.py
+++ b/test.py
@@ -18,6 +18,7 @@ def start_db_container(dbms, cfg, script_log, docker_log):
     image = cfg.get("image")
     container_name = cfg.get("container_name", f"{dbms}-sqlancer")
     env_dict = cfg.get("env", {})
+    startup_cmd = cfg.get("startup_cmd", [])
 
     if not image:
         script_log.error( "Missing 'image' field in config.json")
@@ -36,7 +37,8 @@ def start_db_container(dbms, cfg, script_log, docker_log):
         "--name", container_name,
         "--network", "sqlancer-net",
         *env_vars,
-        image
+        image,
+        *startup_cmd
     ], docker_log)
 
     script_log.info("Starting DBMS container: %s ...", container_name)


### PR DESCRIPTION
As CockroachDB removed certain cluster settings (e.g. sql.metrics.statement_details.plan_collection.enabled) that are still referenced in SQLancer, 
the newest commit  modifies the SQLancer Dockerfile to remove those references, allowing the build to succeed with the latest CockroachDB.